### PR TITLE
ci: run npm audit on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,25 @@ jobs:
       - name: Run tests
         run: npm test
 
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit
+        run: npm audit
+
   build:
     name: Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add a new `audit` job to CI workflow
- run `npm audit` on pull_request events
- keep existing lint, test, and build jobs unchanged

## Why
- ensure security vulnerability checks run automatically when opening or updating pull requests