### PR TITLE
Firebase Emulator起動経路をNodeラッパー化し、Java 21前提とドキュメント整合を実施

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ npm run dev:emulator
 
 - **Node.js** (v18.17.0以上推奨)
 - **npm** または **yarn**
+- **Java Development Kit (JDK) 21以上** (Firebase Emulator起動に必須)
 - **Firebase プロジェクト** (本番環境の場合)
 
 ### 1. リポジトリクローン
@@ -137,6 +138,8 @@ npm run dev:emulator
 npm run emulator  # Firebaseエミュレーター
 npm run dev       # Next.js開発サーバー（Turbopack）
 ```
+
+`npm run emulator` は `scripts/run-firebase-emulator.mjs` を経由して実行され、Java 21の解決を行ったうえで Firebase CLI を起動します。
 
 #### 本番Firebase接続
 
@@ -396,17 +399,53 @@ npm run emulator   # 別ターミナルでエミュレーターを起動
 npm run dev        # 別ターミナルで開発サーバーを起動
 ```
 
-#### 2. ポート3000/4000が既に使用されている
+#### 2. ポート競合が発生する
 ```bash
 # Macの場合 - 使用中のプロセスを確認・終了
 lsof -i :3000
 kill -9 <PID>
 
+# Emulatorで使用するポート（実装値）
+lsof -i :4001  # Emulator Suite UI
+lsof -i :8081  # Firestore Emulator
+lsof -i :9098  # Auth Emulator
+
 # または、異なるポートで起動
 PORT=3001 npm run dev
 ```
 
-#### 3. Node.js バージョンエラー
+#### 3. `Unable to find JDK 21` エラー
+```bash
+# Javaバージョン確認
+java -version
+
+# Java 21のインストール先をJAVA_HOMEに設定
+# あわせて PATH に $JAVA_HOME/bin を追加
+# 設定後に java -version で 21 以上になっていることを確認
+
+# 再実行
+npm run emulator
+```
+
+補足: シェル別の設定例（必要な場合のみ）
+
+- bash/zsh
+```bash
+export JAVA_HOME=$(/usr/libexec/java_home -v 21)
+export PATH="$JAVA_HOME/bin:$PATH"
+```
+- `java_home -v 21` で見つからない場合（Homebrewのkeg-only構成）
+```bash
+export JAVA_HOME="$(brew --prefix openjdk@21)/libexec/openjdk.jdk/Contents/Home"
+export PATH="$JAVA_HOME/bin:$PATH"
+```
+- fish
+```fish
+set -gx JAVA_HOME (brew --prefix openjdk@21)/libexec/openjdk.jdk/Contents/Home
+fish_add_path $JAVA_HOME/bin
+```
+
+#### 4. Node.js バージョンエラー
 ```bash
 # v18.17.0以上が必須です
 node --version
@@ -416,7 +455,7 @@ nvm install 18.17.0
 nvm use 18.17.0
 ```
 
-#### 4. `npm install` で依存関係インストール失敗
+#### 5. `npm install` で依存関係インストール失敗
 ```bash
 # キャッシュをクリアして再度インストール
 rm -rf node_modules package-lock.json
@@ -424,7 +463,7 @@ npm cache clean --force
 npm install
 ```
 
-#### 5. 環境変数が読み込まれない
+#### 6. 環境変数が読み込まれない
 ```bash
 # .env.local ファイルが存在するか確認
 ls -la | grep env
@@ -433,7 +472,7 @@ ls -la | grep env
 npm run dev   # Ctrl+C で停止後、再実行
 ```
 
-#### 6. テスト実行時の失敗
+#### 7. テスト実行時の失敗
 ```bash
 # 個別テストで詳細エラーを確認
 npm test -- --verbose task-creation.test.tsx

--- a/docs/firebase-setup-guide.md
+++ b/docs/firebase-setup-guide.md
@@ -2,6 +2,11 @@
 
 ## 🚀 開発環境セットアップ
 
+### 前提条件
+
+- Node.js 18.17.0以上
+- JDK 21以上（Firebase Emulator起動に必須）
+
 ### 1. 環境変数設定
 
 `.env.local.example`を`.env.local`にコピーし、Firebase Console から取得した値で更新してください：
@@ -67,17 +72,19 @@ npm run emulator
 npm run dev:emulator
 ```
 
+`npm run emulator` は `scripts/run-firebase-emulator.mjs` を経由し、Java 21を解決した状態で Firebase CLI を起動します。
+
 ### Emulator UI アクセス
 
-- **Emulator Suite UI**: http://localhost:4000
-- **Firestore Emulator**: http://localhost:8080
-- **Auth Emulator**: http://localhost:9099
+- **Emulator Suite UI**: [http://localhost:4001](http://localhost:4001)
+- **Firestore Emulator**: [http://localhost:8081](http://localhost:8081)
+- **Auth Emulator**: [http://localhost:9098](http://localhost:9098)
 
 ## 📊 データ構造
 
 ### Firestore Collections
 
-```
+```text
 /users/{userId}/
   ├── profile/
   │   └── goals (document)
@@ -105,14 +112,24 @@ npm run dev:emulator
 ### よくある問題
 
 1. **エミュレーター接続エラー**
-   - ポート8080/9099が使用中でないか確認
-   - `firebase emulators:start`で個別起動して確認
+   - ポート4001/8081/9098が使用中でないか確認4000, 8080, 9099 を掴んでいる
+   - `npm run emulator`で起動して確認
 
-2. **認証エラー**
+2. **`Unable to find JDK 21` エラー**
+   - `java -version` で Java 21以上か確認
+   - 必要なら `JAVA_HOME` を Java 21 に設定して再実行
+   - あわせて PATH に `$JAVA_HOME/bin` を追加
+
+   補足: シェル別設定例
+   - bash/zsh: `export JAVA_HOME=$(/usr/libexec/java_home -v 21)` と `export PATH="$JAVA_HOME/bin:$PATH"`
+   - `java_home -v 21` で見つからない場合（Homebrewのkeg-only構成）: `export JAVA_HOME="$(brew --prefix openjdk@21)/libexec/openjdk.jdk/Contents/Home"` と `export PATH="$JAVA_HOME/bin:$PATH"`
+   - fish: `set -gx JAVA_HOME (brew --prefix openjdk@21)/libexec/openjdk.jdk/Contents/Home` と `fish_add_path $JAVA_HOME/bin`
+
+3. **認証エラー**
    - `.env.local`の設定値を確認
    - Firebaseプロジェクトでドメインが許可されているか確認
 
-3. **データが表示されない**
+4. **データが表示されない**
    - Emulator UIでデータが正しく保存されているか確認
    - ブラウザの開発者ツールでエラーログ確認
 
@@ -123,7 +140,7 @@ npm run dev:emulator
 npx firebase --version
 
 # Emulator状態確認
-npx firebase emulators:start --only firestore,auth --inspect-functions
+npm run emulator:ui
 
 # プロジェクト状態確認
 npx firebase projects:list

--- a/docs/uncommitted-emulator-change-review-2026-07-18.md
+++ b/docs/uncommitted-emulator-change-review-2026-07-18.md
@@ -1,0 +1,106 @@
+# 未コミット変更レビュー: Firebase Emulator 起動経路の変更
+
+作成日: 2026-07-18
+対象: 未コミット状態の差分
+
+## レビュー結果
+
+### 1. 中: Java 21 の解決方法が限定的で、従来動いていた環境を壊す可能性がある
+
+- 対象箇所: [scripts/run-firebase-emulator.mjs](../scripts/run-firebase-emulator.mjs#L33-L66)
+- 変更内容: JDK 21 を `JAVA_HOME`、macOS の `/usr/libexec/java_home`、Homebrew の固定パスから探すラッパーを追加している。
+- 問題点: `java` コマンド自体の探索がないため、`PATH` 上では Java 21 が使えるが `JAVA_HOME` を設定していない環境や、SDKMAN! / asdf / 独自インストール構成では起動できない。
+- 変更前との差: 変更前は [package.json](../package.json#L12-L13) の script から Firebase CLI を直接呼んでいたため、Java の解決は CLI と OS 標準の探索に委ねられていた。
+- 想定再現条件: Linux / Windows 環境、または macOS でも Homebrew 固定パス以外で Java 21 を管理している開発環境。
+
+### 2. 低: 追加された前提条件と実際のポート設定がドキュメントに反映されていない
+
+- 対象箇所: [README.md](../README.md#L132-L163), [README.md](../README.md#L391-L399), [docs/firebase-setup-guide.md](./firebase-setup-guide.md#L60-L74), [docs/firebase-setup-guide.md](./firebase-setup-guide.md#L107-L126)
+- 変更内容: emulator 起動が新しい Node ラッパー経由になり、JDK 21 が事実上の前提になった。
+- 問題点: README とセットアップガイドには JDK 21 前提の記載がなく、セットアップガイド側はポート案内も実装とずれている。
+- 実装上の正しい設定: [firebase.json](../firebase.json#L2-L17) と [src/lib/firebase.ts](../src/lib/firebase.ts#L41-L48) より、UI は 4001、Firestore は 8081、Auth は 9098 を使用する。
+
+## 実装の全体像
+
+- 変更の目的: `firebase-tools` を 15.24.0 に更新しつつ、Firebase Emulator 起動時に JDK 21 を自動設定する。
+- 主な入口: [package.json](../package.json#L12-L14)
+- 主な変更ファイル:
+  - [package.json](../package.json)
+  - [scripts/run-firebase-emulator.mjs](../scripts/run-firebase-emulator.mjs)
+  - [package-lock.json](../package-lock.json)
+
+## コードポインター付き解説
+
+### [package.json](../package.json)
+
+- [package.json](../package.json#L12-L14): `emulator` と `emulator:ui` を Firebase CLI 直呼びから Node ラッパー呼び出しへ変更。
+- [package.json](../package.json#L36): `firebase-tools` を 14.14.0 から 15.24.0 へ更新。
+
+### [scripts/run-firebase-emulator.mjs](../scripts/run-firebase-emulator.mjs)
+
+- [scripts/run-firebase-emulator.mjs](../scripts/run-firebase-emulator.mjs#L6-L31): `java -version` の出力からメジャーバージョンを判定。
+- [scripts/run-firebase-emulator.mjs](../scripts/run-firebase-emulator.mjs#L33-L66): JDK 21 の探索ロジック本体。
+- [scripts/run-firebase-emulator.mjs](../scripts/run-firebase-emulator.mjs#L71-L73): JDK 21 が見つからない場合にエラー終了。
+- [scripts/run-firebase-emulator.mjs](../scripts/run-firebase-emulator.mjs#L76-L85): `JAVA_HOME` と `PATH` を上書きした状態で `firebase emulators:start` を起動。
+- [scripts/run-firebase-emulator.mjs](../scripts/run-firebase-emulator.mjs#L87-L99): 子プロセスの終了コードやシグナルを親へ引き継ぐ。
+
+### [firebase.json](../firebase.json) と [src/lib/firebase.ts](../src/lib/firebase.ts)
+
+- [firebase.json](../firebase.json#L2-L17): emulator の有効化対象とポート定義。
+- [src/lib/firebase.ts](../src/lib/firebase.ts#L41-L48): 開発時に Auth を 9098、Firestore を 8081 に接続。
+
+## エントリーポイントからの処理フロー
+
+1. 開発者が `npm run emulator` または `npm run dev:emulator` を実行する。
+2. 入口は [package.json](../package.json#L12-L14) で、Node が [scripts/run-firebase-emulator.mjs](../scripts/run-firebase-emulator.mjs#L1-L99) を起動する。
+3. [scripts/run-firebase-emulator.mjs](../scripts/run-firebase-emulator.mjs#L33-L66) が Java 21 の候補を順に調べる。
+4. 候補が見つからなければ [scripts/run-firebase-emulator.mjs](../scripts/run-firebase-emulator.mjs#L71-L73) で即終了する。
+5. 見つかった場合は [scripts/run-firebase-emulator.mjs](../scripts/run-firebase-emulator.mjs#L76-L80) で `JAVA_HOME` と `PATH` を補正する。
+6. 続いて [scripts/run-firebase-emulator.mjs](../scripts/run-firebase-emulator.mjs#L82-L85) が `firebase emulators:start` に元の引数を渡して起動する。
+7. Firebase CLI は [firebase.json](../firebase.json#L2-L17) を読み、auth、firestore、ui のポートを確保する。
+8. フロントエンドは [src/lib/firebase.ts](../src/lib/firebase.ts#L41-L48) で localhost:9098 と 8081 に接続する。
+
+## 変更前後の挙動差分
+
+### 変更前
+
+- npm script から `firebase emulators:start` を直接実行していた。
+- Java の解決は Firebase CLI と OS 標準の探索に委ねていた。
+
+### 変更後
+
+- npm script は必ず Node ラッパーを経由する。
+- macOS で `/usr/libexec/java_home -v 21` か Homebrew の OpenJDK 21 がある環境では、既定 Java が 11 でも Java 21 に差し替えて起動できる。
+- 一方で、探索先が固定化されたため、`PATH` ベースで Java 21 を提供している環境では回帰の可能性がある。
+
+### ユーザー影響
+
+- ローカル環境によっては、以前は起動できた `npm run emulator` が JDK 21 未検出で失敗する。
+- ドキュメントどおりに操作しても、必要な前提条件や正しいポートが分からず、切り分けコストが上がる。
+
+## 検証と前提
+
+### 実行した確認
+
+- `npm run emulator -- --help`
+  - 新しいラッパー経由で Firebase CLI の help 表示まで到達することを確認した。
+- `npm run emulator`
+  - ローカルでは JDK 21 の自動解決は成功した。
+  - 失敗理由は今回の変更そのものではなく、4001 / 9098 / 8081 が使用中だったためだった。
+
+### 未確認事項
+
+- Linux 環境での起動可否
+- Windows 環境での起動可否
+- SDKMAN! / asdf など PATH ベース管理環境での挙動
+
+### 前提
+
+- このレビューは 2026-07-18 時点の未コミット差分を対象にしている。
+- 今後差分が更新された場合、この文書の内容も見直しが必要になる。
+
+## 推奨対応
+
+1. [scripts/run-firebase-emulator.mjs](../scripts/run-firebase-emulator.mjs#L33-L66) に `java` コマンドの PATH 探索を追加する。
+2. [README.md](../README.md#L132-L163) と [docs/firebase-setup-guide.md](./firebase-setup-guide.md#L60-L74) に JDK 21 前提を明記する。
+3. [docs/firebase-setup-guide.md](./firebase-setup-guide.md#L70-L74) と [docs/firebase-setup-guide.md](./firebase-setup-guide.md#L107-L126) のポート表記と起動コマンドを、現行実装に合わせて更新する。

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "concurrently": "^9.2.0",
         "eslint": "^9",
         "eslint-config-next": "^15.5.20",
-        "firebase-tools": "^14.14.0",
+        "firebase-tools": "^15.24.0",
         "jest": "^30.0.5",
         "jest-environment-jsdom": "^30.0.5",
         "tailwindcss": "^4",
@@ -81,41 +81,6 @@
         "@types/json-schema": "^7.0.6",
         "call-me-maybe": "^1.0.1",
         "js-yaml": "^4.1.0"
-      }
-    },
-    "node_modules/@apphosting/build": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@apphosting/build/-/build-0.1.7.tgz",
-      "integrity": "sha512-zNgQGiAWDOj6c+4ylv5ej3nLGXzMAVmzCGMqlbSarHe4bvBmZ2C5GfBRdJksedP7C9pqlwTWpxU5+GSzhJ+nKA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@apphosting/common": "^0.0.9",
-        "@npmcli/promise-spawn": "^3.0.0",
-        "colorette": "^2.0.20",
-        "commander": "^11.1.0",
-        "npm-pick-manifest": "^9.0.0",
-        "ts-node": "^10.9.1"
-      },
-      "bin": {
-        "apphosting-local-build": "dist/bin/localbuild.js"
-      }
-    },
-    "node_modules/@apphosting/build/node_modules/@apphosting/common": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@apphosting/common/-/common-0.0.9.tgz",
-      "integrity": "sha512-ZbPZDcVhEN+8m0sf90PmQN4xWaKmmySnBSKKPaIOD0JvcDsRr509WenFEFlojP++VSxwFZDGG/TYsHs1FMMqpw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@apphosting/build/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@apphosting/common": {
@@ -2454,18 +2419,28 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.1.tgz",
-      "integrity": "sha512-bevKGO6kX1eM/N+pdh9leS5L7TBF4ICrzi9a+cbWkrxeAeIcwlo/7OfWGCDERdRCI2/Q6tjltX4bt07ALHDwFw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/figures": "^1.0.13",
-        "@inquirer/type": "^3.0.8",
-        "ansi-escapes": "^4.3.2",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -2480,14 +2455,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.15.tgz",
-      "integrity": "sha512-SwHMGa8Z47LawQN0rog0sT+6JpiL0B7eW9p1Bb7iCeKDGTI5Ez25TSc2l8kw52VV7hA4sX/C78CGkMrKXfuspA==",
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -2502,20 +2477,20 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
-      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.13",
-        "@inquirer/type": "^3.0.8",
-        "ansi-escapes": "^4.3.2",
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
         "signal-exit": "^4.1.0",
         "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -2580,15 +2555,15 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.17",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.17.tgz",
-      "integrity": "sha512-r6bQLsyPSzbWrZZ9ufoWL+CztkSatnJ6uSxqd6N+o41EZC51sQeWOzI6s5jLb+xxTWxl7PlUppqm8/sow241gg==",
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/external-editor": "^1.0.1",
-        "@inquirer/type": "^3.0.8"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -2603,15 +2578,15 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.17.tgz",
-      "integrity": "sha512-PSqy9VmJx/VbE3CT453yOfNa+PykpKg/0SYP7odez1/NWBGuDXgPhp4AeGYYKjhLn5lUUavVS/JbeYMPdH50Mw==",
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -2626,14 +2601,14 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.1.tgz",
-      "integrity": "sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chardet": "^2.1.0",
-        "iconv-lite": "^0.6.3"
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
       },
       "engines": {
         "node": ">=18"
@@ -2647,10 +2622,27 @@
         }
       }
     },
+    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
-      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2658,14 +2650,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.1.tgz",
-      "integrity": "sha512-tVC+O1rBl0lJpoUZv4xY+WGWY8V5b0zxU1XDsMsIHYregdh7bN5X5QnIONNBAl0K765FYlAfNHS2Bhn7SSOVow==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -2680,14 +2672,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.17.tgz",
-      "integrity": "sha512-GcvGHkyIgfZgVnnimURdOueMk0CztycfC8NZTiIY9arIAkeOgt6zG57G+7vC59Jns3UX27LMkPKnKWAOF5xEYg==",
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -2702,15 +2694,15 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.17.tgz",
-      "integrity": "sha512-DJolTnNeZ00E1+1TW+8614F7rOJJCM4y4BAGQ3Gq6kQIG+OJ4zr3GLjIjVVJCbKsk2jmkmv6v2kQuN/vriHdZA==",
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8",
-        "ansi-escapes": "^4.3.2"
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -2725,22 +2717,22 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.8.3.tgz",
-      "integrity": "sha512-iHYp+JCaCRktM/ESZdpHI51yqsDgXu+dMs4semzETftOaF8u5hwlqnbIsuIR/LrWZl8Pm1/gzteK9I7MAq5HTA==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.2.1",
-        "@inquirer/confirm": "^5.1.15",
-        "@inquirer/editor": "^4.2.17",
-        "@inquirer/expand": "^4.0.17",
-        "@inquirer/input": "^4.2.1",
-        "@inquirer/number": "^3.0.17",
-        "@inquirer/password": "^4.0.17",
-        "@inquirer/rawlist": "^4.1.5",
-        "@inquirer/search": "^3.1.0",
-        "@inquirer/select": "^4.3.1"
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
       },
       "engines": {
         "node": ">=18"
@@ -2755,15 +2747,15 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.5.tgz",
-      "integrity": "sha512-R5qMyGJqtDdi4Ht521iAkNqyB6p2UPuZUbMifakg1sWtu24gc2Z8CJuw8rP081OckNDMgtDCuLe42Q2Kr3BolA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -2778,16 +2770,16 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.1.0.tgz",
-      "integrity": "sha512-PMk1+O/WBcYJDq2H7foV0aAZSmDdkzZB9Mw2v/DmONRJopwA/128cS9M/TXWLKKdEQKZnKwBzqu2G4x/2Nqx8Q==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/figures": "^1.0.13",
-        "@inquirer/type": "^3.0.8",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -2802,17 +2794,17 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.3.1.tgz",
-      "integrity": "sha512-Gfl/5sqOF5vS/LIrSndFgOh7jgoe0UXEizDqahFRkq5aJBLegZ6WjuMh/hVEJwlFQjyLq1z9fRtvUMkb7jM1LA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/figures": "^1.0.13",
-        "@inquirer/type": "^3.0.8",
-        "ansi-escapes": "^4.3.2",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -2827,9 +2819,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
-      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4139,19 +4131,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
-      }
-    },
-    "node_modules/@npmcli/promise-spawn": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-3.0.0.tgz",
-      "integrity": "sha512-s9SgS+p3a9Eohe68cSI3fi+hpcZUmXq5P7w0kMlAsWVtR7XbK3ptkZqKT2cK1zLDObJ3sR+8P59sJE0w/KTL1g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "infer-owner": "^1.0.4"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -7217,9 +7196,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
-      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
       "dev": true,
       "license": "MIT"
     },
@@ -8335,17 +8314,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-equal-in-any-order": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/deep-equal-in-any-order/-/deep-equal-in-any-order-2.0.6.tgz",
-      "integrity": "sha512-RfnWHQzph10YrUjvWwhd15Dne8ciSJcZ3U6OD7owPwiVwsdE5IFSoZGg8rlwJD11ES+9H5y8j3fCofviRHOqLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash.mapvalues": "^4.6.0",
-        "sort-any": "^2.0.0"
       }
     },
     "node_modules/deep-extend": {
@@ -9916,16 +9884,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/filesize": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.4.0.tgz",
-      "integrity": "sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -10029,20 +9987,19 @@
       }
     },
     "node_modules/firebase-tools": {
-      "version": "14.27.0",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-14.27.0.tgz",
-      "integrity": "sha512-HrucHJ69mLM9pQhZFO1rb0N/QMpZD4iznoOtKd2lctEELPtbSMN5JHgdgzLlf+EXn5aQy87u5zlPd/0xwwyYTQ==",
+      "version": "15.24.0",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-15.24.0.tgz",
+      "integrity": "sha512-2P5qd3O3YD7a7AaA89lt/zgRIgR7FGS0Ye7fW9z/sNt9/b6cbmI1TtQtYDlmJDUOh9nMk+72ll/gu4MlN/qY7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@apphosting/build": "^0.1.6",
         "@apphosting/common": "^0.0.8",
         "@electric-sql/pglite": "^0.3.3",
         "@electric-sql/pglite-tools": "^0.2.8",
         "@google-cloud/cloud-sql-connector": "^1.3.3",
         "@google-cloud/pubsub": "^5.2.0",
-        "@inquirer/prompts": "^7.4.0",
-        "@modelcontextprotocol/sdk": "^1.10.2",
+        "@inquirer/prompts": "^7.10.1",
+        "@modelcontextprotocol/sdk": "^1.24.0",
         "abort-controller": "^3.0.0",
         "ajv": "^8.17.1",
         "ajv-formats": "3.0.1",
@@ -10059,24 +10016,21 @@
         "cross-env": "^7.0.3",
         "cross-spawn": "^7.0.5",
         "csv-parse": "^5.0.4",
-        "deep-equal-in-any-order": "^2.0.6",
         "exegesis": "^4.2.0",
         "exegesis-express": "^4.0.0",
         "express": "^4.16.4",
-        "filesize": "^6.1.0",
         "form-data": "^4.0.1",
         "fs-extra": "^10.1.0",
         "fuzzy": "^0.1.3",
         "gaxios": "^6.7.0",
-        "glob": "^10.4.1",
+        "glob": "^10.5.0",
         "google-auth-library": "^9.11.0",
         "ignore": "^7.0.4",
-        "js-yaml": "^3.14.1",
-        "jsonwebtoken": "^9.0.0",
-        "leven": "^3.1.0",
+        "js-yaml": "^4.2.0",
+        "jsonwebtoken": "^9.0.2",
         "libsodium-wrappers": "^0.7.10",
-        "lodash": "^4.17.21",
-        "lsofi": "1.0.0",
+        "lodash": "^4.18.0",
+        "lsofi": "^2.0.0",
         "marked": "^13.0.2",
         "marked-terminal": "^7.0.0",
         "mime": "^2.5.2",
@@ -10085,7 +10039,6 @@
         "node-fetch": "^2.6.7",
         "open": "^6.3.0",
         "ora": "^5.4.1",
-        "p-limit": "^3.0.1",
         "pg": "^8.11.3",
         "pg-gateway": "^0.3.0-beta.4",
         "pglite-2": "npm:@electric-sql/pglite@0.2.17",
@@ -10098,19 +10051,18 @@
         "stream-chain": "^2.2.4",
         "stream-json": "^1.7.3",
         "superstatic": "^10.0.0",
-        "tar": "^6.1.11",
+        "tar": "^7.5.11",
         "tcp-port-used": "^1.0.2",
         "tmp": "^0.2.3",
         "triple-beam": "^1.3.0",
+        "undici": "^6.19.0",
         "universal-analytics": "^0.5.3",
         "update-notifier-cjs": "^5.1.6",
-        "uuid": "^8.3.2",
         "winston": "^3.0.0",
         "winston-transport": "^4.4.0",
         "ws": "^7.5.10",
-        "yaml": "^2.4.1",
-        "zod": "^3.24.3",
-        "zod-to-json-schema": "^3.24.5"
+        "yaml": "^2.8.3",
+        "zod": "^4.0.0"
       },
       "bin": {
         "firebase": "lib/bin/firebase.js"
@@ -10136,52 +10088,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/firebase-tools/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/firebase-tools/node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -10190,20 +10096,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/firebase-tools/node_modules/json-schema-traverse": {
@@ -10224,74 +10116,6 @@
       },
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/firebase-tools/node_modules/ws": {
@@ -10315,13 +10139,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/firebase-tools/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
@@ -11339,26 +11156,6 @@
         "node": ">=16.9.0"
       }
     },
-    "node_modules/hosted-git-info": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^10.0.1"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/hosted-git-info/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -11557,13 +11354,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/infer-owner": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -11748,13 +11538,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
@@ -13663,19 +13446,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
@@ -14131,13 +13901,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.mapvalues": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -14248,27 +14011,13 @@
       "license": "ISC"
     },
     "node_modules/lsofi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lsofi/-/lsofi-1.0.0.tgz",
-      "integrity": "sha512-MKr9vM1MSm+TSKfI05IYxpKV1NCxpJaBLnELyIf784zYJ5KV9lGCE1EvpA2DtXDNM3fCuFeCwXUzim/fyQRi+A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lsofi/-/lsofi-2.0.0.tgz",
+      "integrity": "sha512-XTFlOBHeuXnUGuUQI0kBb4O4oQW7qCV7MRGQja1xNpxgrI/jptlly+/5126RiRold1zgyxY520qOZUZ31V0I2A==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "is-number": "^2.1.0",
-        "through2": "^2.0.1"
-      }
-    },
-    "node_modules/lsofi/node_modules/is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/lz-string": {
@@ -15021,61 +14770,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm-install-checks": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-6.3.0.tgz",
-      "integrity": "sha512-W29RiK/xtpCGqn6f3ixfRYGk+zRyr+Ew9F2E20BfXxT5/euLdA/Nm7fO7OeTGuAmTs30cpgInyJ0cYe708YTZw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "semver": "^7.1.1"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm-normalize-package-bin": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
-      "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm-package-arg": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
-      "integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "proc-log": "^4.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-name": "^5.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm-pick-manifest": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.1.0.tgz",
-      "integrity": "sha512-nkc+3pIIhqHVQr085X9d2JzPzLyjzQS96zbruppqC9aZRm/x8xx6xhI98gHtsfELP2bE+loHq8ZaHFHhe+NauA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-install-checks": "^6.0.0",
-        "npm-normalize-package-bin": "^3.0.0",
-        "npm-package-arg": "^11.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -15995,16 +15689,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/proc-log": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
-      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -17332,16 +17016,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/sort-any": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sort-any/-/sort-any-2.0.0.tgz",
-      "integrity": "sha512-T9JoiDewQEmWcnmPn/s9h/PH9t3d/LSWi0RgVmXSuDYeZXTZOZ1/wrK2PHaptuR1VXe3clLLt0pD6sgVOwjNEA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -18196,57 +17870,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/through2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -18764,7 +18387,6 @@
       "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18.17"
       }
@@ -18981,16 +18603,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -19018,16 +18630,6 @@
       "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
       "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==",
       "dev": true
-    },
-    "node_modules/validate-npm-package-name": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
-      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -19724,9 +19326,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint",
     "test": "NODE_OPTIONS=--max_old_space_size=4096 jest --verbose",
     "test:watch": "NODE_OPTIONS=--max_old_space_size=4096 jest --watch",
-    "emulator": "firebase emulators:start --project demo-toeic-study-app",
-    "emulator:ui": "firebase emulators:start --project demo-toeic-study-app --only firestore,auth --inspect-functions",
+    "emulator": "node scripts/run-firebase-emulator.mjs --project demo-toeic-study-app",
+    "emulator:ui": "node scripts/run-firebase-emulator.mjs --project demo-toeic-study-app --only firestore,auth --inspect-functions",
     "dev:emulator": "concurrently \"npm run emulator\" \"npm run dev\""
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "concurrently": "^9.2.0",
     "eslint": "^9",
     "eslint-config-next": "^15.5.20",
-    "firebase-tools": "^14.14.0",
+    "firebase-tools": "^15.24.0",
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.0.5",
     "tailwindcss": "^4",

--- a/scripts/run-firebase-emulator.mjs
+++ b/scripts/run-firebase-emulator.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+function parseJavaMajorVersion(output) {
+  const match = output.match(/version "(\d+)(?:\.(\d+))?/);
+
+  if (!match) {
+    return undefined;
+  }
+
+  const major = Number(match[1]);
+
+  if (major === 1 && match[2]) {
+    return Number(match[2]);
+  }
+
+  return major;
+}
+
+function getJavaMajorVersion(javaHome) {
+  const result = spawnSync(path.join(javaHome, 'bin', 'java'), ['-version'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+  return parseJavaMajorVersion(output);
+}
+
+function isJava21OrNewer(javaHome) {
+  const majorVersion = getJavaMajorVersion(javaHome);
+  return typeof majorVersion === 'number' && majorVersion >= 21;
+}
+
+function resolveJavaHomeFromPath() {
+  const versionResult = spawnSync('java', ['-version'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (versionResult.error) {
+    return undefined;
+  }
+
+  const versionOutput = `${versionResult.stdout ?? ''}${versionResult.stderr ?? ''}`;
+  const majorVersion = parseJavaMajorVersion(versionOutput);
+
+  if (typeof majorVersion !== 'number' || majorVersion < 21) {
+    return undefined;
+  }
+
+  const settingsResult = spawnSync('java', ['-XshowSettings:properties', '-version'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (settingsResult.error) {
+    return undefined;
+  }
+
+  const settingsOutput = `${settingsResult.stdout ?? ''}${settingsResult.stderr ?? ''}`;
+  const homeMatch = settingsOutput.match(/^\s*java\.home\s*=\s*(.+)$/m);
+
+  if (!homeMatch) {
+    return undefined;
+  }
+
+  const javaHome = homeMatch[1].trim();
+
+  if (javaHome.length === 0) {
+    return undefined;
+  }
+
+  if (isJava21OrNewer(javaHome)) {
+    return javaHome;
+  }
+
+  return undefined;
+}
+
+function resolveJavaHome() {
+  if (process.env.JAVA_HOME && process.env.JAVA_HOME.length > 0) {
+    if (isJava21OrNewer(process.env.JAVA_HOME)) {
+      return process.env.JAVA_HOME;
+    }
+  }
+
+  const pathJavaHome = resolveJavaHomeFromPath();
+  if (pathJavaHome) {
+    return pathJavaHome;
+  }
+
+  if (process.platform === 'darwin') {
+    try {
+      const resolved = execFileSync('/usr/libexec/java_home', ['-v', '21'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).trim();
+
+      if (resolved.length > 0 && isJava21OrNewer(resolved)) {
+        return resolved;
+      }
+    } catch {
+      // Fall through to common Homebrew locations.
+    }
+  }
+
+  const brewCandidates = [
+    '/usr/local/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home',
+    '/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home',
+  ];
+
+  for (const candidate of brewCandidates) {
+    if (existsSync(candidate) && isJava21OrNewer(candidate)) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+const javaHome = resolveJavaHome();
+
+if (!javaHome) {
+  console.error('Unable to find JDK 21. Install Java 21, then set JAVA_HOME or make `java` (21+) available in PATH.');
+  process.exit(1);
+}
+
+const env = {
+  ...process.env,
+  JAVA_HOME: javaHome,
+  PATH: `${path.join(javaHome, 'bin')}${path.delimiter}${process.env.PATH ?? ''}`,
+};
+
+const child = spawn('firebase', ['emulators:start', ...process.argv.slice(2)], {
+  env,
+  stdio: 'inherit',
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 1);
+});
+
+child.on('error', (error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## 概要
Firebase Emulator の起動経路を Node ラッパー経由に変更し、Java 21 前提の明確化とドキュメント整合を行いました。

## 変更内容
- chore(deps): firebase-tools を 15.24.0 へ更新
- feat(emulator): npm scripts の emulator / emulator:ui を Node ラッパー経由へ変更
- feat(emulator): Java 21 解決ラッパー `scripts/run-firebase-emulator.mjs` を追加
  - `JAVA_HOME` 優先
  - PATH 上の `java` から `java.home` を逆引き
  - macOS `/usr/libexec/java_home -v 21`
  - Homebrew 既定パス
- docs(emulator): README / firebase-setup-guide の前提条件とトラブルシュートを更新
  - JDK 21 前提を追記
  - エミュレーターポートを実装値 (4001/8081/9098) に整合
  - シェル依存の手順は補足として分離
- docs(review): 未コミット差分レビューの記録を追加

## 背景
- emulator 起動失敗時の原因を明確化したい
- ドキュメント上のポート表記が実装値とずれていたため整合が必要

## 検証
- `npm run emulator -- --help` がラッパー経由で実行されること
- ローカルで Java 21 解決と起動経路を確認

## 影響範囲
- ローカル開発時の emulator 起動経路
- セットアップ手順・トラブルシューティング文書
